### PR TITLE
release: cost-katana 2.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to Cost Katana Python SDK will be documented in this file.
 
 ## [Unreleased]
 
+## [2.5.6] - 2026-04-29
+
 ### Fixed
 
 - **GitHub Actions**: Use automatic `github.token` instead of invalid `secrets.GITHUB_TOKEN` for `actions/checkout` and releases (`auto-release.yml`, `version-bump.yml`, `publish.yml`).
+- **Auto Release**: Build artifacts **after** bumping `setup.py` / `cost_katana/__init__.py` so PyPI uploads are not stale duplicates (fixes HTTP 400 on upload).
+- **Version Bump workflow**: Install **`setuptools`** for `setup.py --version`; keep **`__version__`** in sync when bumping.
 - **CI typing**: Resolve **`mypy`** errors across `cost_katana` (`Logger`, `AILogger`, `TemplateManager`, `CostKatanaClient`, `SimpleResponse.templateUsed`, Optional template parameters).
 - **CI security**: **`bandit`** clean on current sources; **`safety`** scoped to `requirements.txt` so transitive dev-only CVE noise does not fail the workflow.
 

--- a/cost_katana/__init__.py
+++ b/cost_katana/__init__.py
@@ -56,7 +56,7 @@ from .models_constants import (
     get_provider_from_model,
 )
 
-__version__ = "2.5.5"
+__version__ = "2.5.6"
 
 
 def track(entry: Dict[str, Any]) -> None:

--- a/cost_katana/client.py
+++ b/cost_katana/client.py
@@ -170,7 +170,7 @@ class CostKatanaClient:
         headers: Dict[str, str] = {
             "Authorization": f"Bearer {self.config.api_key}",
             "Content-Type": "application/json",
-            "User-Agent": "cost-katana-python/2.5.5",
+            "User-Agent": "cost-katana-python/2.5.6",
         }
         if self.config.project_id:
             headers["x-project-id"] = self.config.project_id

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="cost-katana",
-    version="2.5.5",
+    version="2.5.6",
     author="Cost Katana Team",
     author_email="support@costkatana.com",
     description="The simplest way to use AI in Python with automatic cost tracking and optimization",


### PR DESCRIPTION
## Summary
Bump Python SDK to **2.5.6** for PyPI (CHANGELOG notes CI/release workflow fixes).

## After merge (maintainer)
Protected `master` blocks automated Version Bump pushes; merge this PR, then create and push tag **v2.5.6** on `master` to trigger **Build and Publish to PyPI**:

```bash
git checkout master && git pull origin master
git tag -a v2.5.6 -m "Release 2.5.6"
git push origin v2.5.6
```

Alternatively create release **v2.5.6** from the GitHub Releases UI.